### PR TITLE
Fix bug with range calculation when multiple ACs & zones present

### DIFF
--- a/pyairtouch/at4/api.py
+++ b/pyairtouch/at4/api.py
@@ -855,7 +855,9 @@ class AirTouch4(pyairtouch.api.AirTouch):
                 # group_count here.
                 ac_zones = [
                     self._zones[zone_id]
-                    for zone_id in range(ac.start_group, ac.group_count)
+                    for zone_id in range(
+                        ac.start_group, ac.start_group + ac.group_count
+                    )
                 ]
 
             self._air_conditioners[ac.ac_number] = At4AirConditioner(

--- a/pyairtouch/at5/api.py
+++ b/pyairtouch/at5/api.py
@@ -876,9 +876,14 @@ class AirTouch5(pyairtouch.api.AirTouch):
             )
 
     def _process_ac_ability_message(self, ac_abilities: Sequence[AcAbility]) -> None:
+        # With multiple ac's, the start/count values might look like:
+        # AC1: start_zone:0, zone_count: 3
+        # AC2: start_zone:3, zone_count: 2
+        # AC3: start_zone:5, zone_count: 3
         for ac in ac_abilities:
+            _LOGGER.debug("_process_ac_ability_message %s", ac)
             ac_zones = [
-                self._zones[zone_id] for zone_id in range(ac.start_zone, ac.zone_count)
+                self._zones[zone_id] for zone_id in range(ac.start_zone, ac.start_zone + ac.zone_count)
             ]
             self._air_conditioners[ac.ac_number] = At5AirConditioner(
                 ac_number=ac.ac_number,

--- a/pyairtouch/at5/api.py
+++ b/pyairtouch/at5/api.py
@@ -881,9 +881,9 @@ class AirTouch5(pyairtouch.api.AirTouch):
         # AC2: start_zone:3, zone_count: 2
         # AC3: start_zone:5, zone_count: 3
         for ac in ac_abilities:
-            _LOGGER.debug("_process_ac_ability_message %s", ac)
             ac_zones = [
-                self._zones[zone_id] for zone_id in range(ac.start_zone, ac.start_zone + ac.zone_count)
+                self._zones[zone_id]
+                for zone_id in range(ac.start_zone, ac.start_zone + ac.zone_count)
             ]
             self._air_conditioners[ac.ac_number] = At5AirConditioner(
                 ac_number=ac.ac_number,


### PR DESCRIPTION
I was running into problems with missing zones (from multiple AC units), and I think I have found the fix.  Known to work on a unit with 3 ACs and a total of 8 zones (AirTouch5).